### PR TITLE
Add all the caches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoloader",
-  "version": "0.8.1",
+  "version": "1.0.0",
   "main": "out/index.js",
   "author": "Tiddo Langerak <tiddolangerak@gmail.com>",
   "license": "Apache-2.0",

--- a/src/VinylCache.js
+++ b/src/VinylCache.js
@@ -1,0 +1,44 @@
+let crypto = require('crypto');
+
+function getHash(vinylFile) {
+	return crypto.createHash('md5').update(vinylFile.contents).digest('hex');
+}
+
+/**
+ * Class that uses a vinyl object as its key.
+ *
+ * It uses a checksum of the vinyl objects content to determine if the file has changed and thus
+ * if the value associated with the object is still valid.
+ */
+class VinylCache {
+	constructor() {
+		this.hashes = {};
+		this.cache = {};
+	}
+	/**
+	 * Get a value for a given vinyl file
+	 *
+	 * If no value is found or if the hashes don't match null is returned. If the second parameter is
+	 * set to true then the hash will be ignored and any found value will be returned.
+	 */
+	get(vinylFile, ignoreHash) {
+		let cached = this.cache[vinylFile.path];
+		if (ignoreHash) {
+			return cached || null;
+		}
+		if (cached) {
+			let hash = getHash(vinylFile);
+			if (this.hashes[vinylFile.path] === hash) {
+				return cached;
+			}
+		}
+		return null;
+	}
+	set(vinylFile, content) {
+		this.cache[vinylFile.path] = content;
+		let hash = getHash(vinylFile);
+		this.hashes[vinylFile.path] = hash;
+	}
+}
+
+module.exports = VinylCache;

--- a/src/dependencyResolver.js
+++ b/src/dependencyResolver.js
@@ -29,7 +29,8 @@ module.exports = function dependencyResolver(chunk, instance) {
 	return function resolveDependency(depName, done) {
 		debug('Resolving dependency from ' + chunk.path + ' to ' + depName);
 
-		//TODO: async cache
+		//TODO: cache promises instead such that fast successive calls for the same file
+		//still are only resolved once.
 		let cached = instance.resolverCache[chunk.path][depName];
 		if (cached) {
 			//If we've found the file in cache then it doesn't necessarily mean it still exists.

--- a/src/index.js
+++ b/src/index.js
@@ -387,6 +387,7 @@ class Yoloader {
 	}
 
 	resolveDependencies(compiler) {
+		compiler = compiler || (stream) => stream;
 		return new Resolver(this, compiler).resolveDependencies();
 	}
 	bundle(bundleOpts) {

--- a/src/index.js
+++ b/src/index.js
@@ -63,9 +63,8 @@ let transformers = {
 		instance.dependencyCache = instance.dependencyCache || new VinylCache();
 
 		return through.obj((chunk, enc, done) => {
-			let content = chunk.contents.toString();
 			//We first try to get dependencies from cache.
-			//Only if that fails we'll find them again
+			//Only if that fails we'll try to find them again
 			let cachedDeps = instance.dependencyCache.get(chunk);
 
 			if (cachedDeps) {
@@ -74,7 +73,7 @@ let transformers = {
 				let timer = startTimer('findDeps');
 				chunk.deps = {};
 
-				detective(content)
+				detective(chunk.contents.toString())
 					//For now all dependencies will have value null since they're not resolved yet
 					.forEach((dep) => chunk.deps[dep] = null);
 

--- a/src/index.js
+++ b/src/index.js
@@ -102,27 +102,14 @@ let transformers = {
 		});
 	},
 
-	compileDependencies (instance, compile) {
+	compileDependencies (instance, compile, resolver) {
 		//TODO: more efficient duplicate checking
 		return through.obj(function (chunk, enc, done) {
 			let timer = startTimer('compileDepsPrepare');
 
 			let outer = this;
-			//We don't want to compile the same file twice, so we remove those that we've seen already
-			//here, and additionally we update the filesCompiled list
-			let newFiles = values(chunk.deps)
-				.filter((dep) => {
-					return instance.filesCompiled.indexOf(dep.file) === -1 &&
-						instance.filesPending.indexOf(dep.file) === -1;
-				});
-			instance.filesPending = instance.filesPending.concat(newFiles.map((file) => file.file));
-
-			//Note: we can only push the chunk when we're done with it's properties: as soon as the chunk
-			//is pushed it will be piped trough the rest of the pipeline, which might alter the object.
-			if (instance.filesCompiled.indexOf(chunk.path) === -1) {
-				instance.filesCompiled.push(chunk.path);
-				this.push(chunk);
-			}
+			this.push(chunk, enc);
+			let newFiles = values(chunk.deps);
 			let latch = countDownLatch(newFiles.length, () =>  done());
 			timer.stop();
 			newFiles.forEach((file) => {
@@ -130,11 +117,13 @@ let transformers = {
 				let compileStream = compile(file.file, file.base);
 				//If the compile function didn't return anything then we ignore the file.
 				if (compileStream) {
-					compileStream.pipe(through.obj((chunk, enc, cb) => {
-						outer.push(chunk);
-						//IMPORTANT: if we push the chunk here to the inner stream stuff blows up.
-						//I don't know why (yet), but just don't do it
-						cb();
+					compileStream
+						.pipe(resolver.resolveDependencies())
+						.pipe(through.obj((chunk, enc, cb) => {
+							outer.push(chunk);
+							//IMPORTANT: if we push the chunk here to the inner stream stuff blows up.
+							//I don't know why (yet), but just don't do it
+							cb();
 					}, (cb) => { latch.countDown(); cb(); } ));
 				} else {
 					latch.countDown();
@@ -331,6 +320,30 @@ function createPipeline(transformers, ...opts) {
 	return combine(transformers.map(binder(...opts)).map(invoke));
 }
 
+class Resolver {
+	constructor(yoloaderInstance, compiler) {
+		this.yoloader = yoloaderInstance;
+		this.compiler = compiler;
+		this.filesProcessed = new Set();
+	}
+	resolveDependencies() {
+		let id = Math.random();
+		let processor = this.yoloader.dependencyProcessor(this.yoloader, this.compiler, this);
+
+		let self = this;
+		//Filter the calls such that we only ever compile each file once
+		let filter = through.obj((chunk, enc, done) => {
+			if (self.filesProcessed.has(chunk.path)) {
+				return done(null, null);
+			} else {
+				self.filesProcessed.add(chunk.path);
+				return done(null, chunk);
+			}
+		});
+		return combine(filter, processor);
+	}
+}
+
 class Yoloader {
 	constructor(options = {}) {
 		this.dependencyProcessorPipeline = dependencyPipeline;
@@ -361,7 +374,7 @@ class Yoloader {
 	}
 
 	resolveDependencies(compiler) {
-		return this.dependencyProcessor(this, compiler);
+		return new Resolver(this, compiler).resolveDependencies();
 	}
 	bundle(bundleOpts) {
 		return this.bundler(this, bundleOpts);

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ let beautify = require('js-beautify');
 let bundleSerializer = require('./bundleSerializer');
 let countDownLatch = require('./countDownLatch');
 let UnresolvedDependenciesError = require('./errors/UnresolvedDependenciesError');
+let crypto = require('crypto');
 
 //Very simple ad hoc profiling implementation. I couldn't find any good non-continuous profiling
 //libraries in a couple of minutes, so writing my own is faster here. (suggestions for better frameworks
@@ -51,19 +52,28 @@ if (process.env.YOLOADER_PROFILE) {
 		console.log(totalTimings);
 	};
 }
+
 let transformers = {
 
 	/**
 	 * Finds and attaches dependencies of a file
 	 */
 	findDependencies (instance) {
+		instance.dependencyCache = instance.dependencyCache || {};
 		return through.obj((chunk, enc, done) => {
-			let timer = startTimer('findDeps');
-			chunk.deps = {};
-			detective(chunk.contents.toString())
-				//For now all dependencies will have value null since they're not resolved yet
-				.forEach((dep) => chunk.deps[dep] = null );
-			timer.stop();
+			let content = chunk.contents.toString();
+			let hash = crypto.createHash('md5').update(content).digest('hex');
+			let cachedDeps = instance.dependencyCache[hash];
+			if (cachedDeps) {
+				chunk.deps = cachedDeps;
+			} else {
+				let timer = startTimer('findDeps');
+				instance.dependencyCache[hash] = chunk.deps = {};
+				detective(content)
+					//For now all dependencies will have value null since they're not resolved yet
+					.forEach((dep) => chunk.deps[dep] = null );
+				timer.stop();
+			}
 			done(null, chunk);
 		});
 	},
@@ -77,7 +87,10 @@ let transformers = {
 			//Push the current file, we'll need that anyway
 			let onSuccess = catcher(done);
 
-			let deps = Object.keys(chunk.deps);
+			let deps = Object.keys(chunk.deps)
+				.filter((dep) => {
+					return !chunk.deps[dep];
+				});
 
 			async.map(deps, dependencyResolver(chunk, instance), onSuccess((resolvedDeps) => {
 				//Check if we've found all dependencies:


### PR DESCRIPTION
In this PR:

- Very basic ad hoc profiler (results are not always accurate when dealing with async stuff, but it's a useful tool to have nonetheless)
- Changed the pre-compilation interface:
  - Compile callback now doesn't need to recursively call `resolveDependencies`. Instead it should just provide the means to compile files from <format-X> to javascript and the `resolveDependencies` function will handle the recursion itself.
  - Compile callback now receives a stream as argument instead of pathnames. 
  - The compile function is now optional, default is the identity function.
- Duplicate filtering is now implemented in the `resolveDependencies` function instead of on the Yoloader instance. In practice this means that a Yoloader instance can now be reused for multiple compilations (this was also one of the main motivations for the changes to the `pre-compilation` interface).
- The dependencies of a given file is now cached based on the files content
- Results of require calls are cached as well 

Results:
I haven't done any actual benchmarking, but I have tested this with the Magnet.me project:
- First time compilation of the Magnet.me project is about 15-20% faster (from 13ish to 11ish seconds on my pc)
- Incremental compilation (i.e. reuse of the same yoloader instance) is about 40% faster (from 13ish to 7.5ish seconds on my pc)

@Magnetme/developers - Ready for review!