### PR TITLE
Fixed compilation for initial files & sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,16 @@ that file accessible for the browser.
 ## Advanced usage
 
 ### Additional compilation steps
-The `resolveDependencies` function accepts a callback that will be called with with vinyl streams for
-each file that it finds. You can implement any compilation step you like here, as long as you return
+The `resolveDependencies` function accepts a callback that provides a vinyl transformer.
+You can implement any compilation step you like here, as long as the transformation results in
 a stream containing javascript files such that yoloader can parse it for dependencies. Keep in mind though that
 the `resolveDependencies` function will call the compile function with *all* dependencies, so the
 dependencies from `node_modules` will also be compiled with your compile function. (Tip: use [gulp-if](https://github.com/robrich/gulp-if) to conditionally apply your compilation steps to just your own files. Also works without gulp.)
 
 Use [babel](https://github.com/babel/babel) to compile from es6 to es5:
 ```javascript
-function compile(stream) {
-	return stream
-		.pipe(babel());
+function compile() {
+	return babel();
 }
 ```
 
@@ -86,10 +85,11 @@ Sourcemap support is enabled via [gulp-sourcemaps](https://www.npmjs.com/package
 It should be initialized in the compile function such that all files will have sourcemaps enabled.
 
 ```javascript
-function compile(stream) {
-	return stream
-		.pipe(sourcemaps.init())
-		.pipe(babel())
+function compile() {
+	return combine(
+		sourcemaps.init(),
+		babel()
+	);
 }
 
 vinylFs.src(entries, { base : root }
@@ -135,10 +135,11 @@ Transformer that exposes the node style `__dirname` and `__filename` properties 
 
 Example:
 ```javascript
-function compile(stream)
-	return stream
-		.pipe(sourcemaps.init())
-		.pipe(dirname())
+function compile()
+	return combine(
+		sourcemaps.init(),
+		dirname()
+	);
 }
 ```
 
@@ -150,9 +151,8 @@ This plugin can be used to wrap browserify transformers such that they can be us
 
 Example (using the [brfs](https://github.com/substack/brfs) transformer):
 ```javascript
-function compile(stream) {
-	return stream
-		.pipe(transform(brfs))
+function compile() {
+	return transform(brfs);
 }
 ```
 
@@ -178,9 +178,8 @@ shimConfig[pathToAngularJs] = {
 	exports : 'angular'
 };
 
-function compile(stream) {
-	return stream
-		.pipe(shim(shimConfig))
+function compile() {
+	return shim(shimConfig);
 }
 
 ```
@@ -236,9 +235,10 @@ var packageOptions = {
 };
 
 function compile(stream) {
-	return stream
-		.pipe(packageCompile(packageOptions))
-		.pipe(yoloader.resolveDependencies(opts));
+	return combine(
+		packageCompile(packageOptions),
+		yoloader.resolveDependencies(opts)
+	);
 }
 
 //etc.

--- a/src/bundleSerializer.js
+++ b/src/bundleSerializer.js
@@ -33,8 +33,10 @@ function serializeModule(module, bundleState) {
 	//We need every file to end in a newline, otherwise it might break stuff (e.g. when it ends in a linecomment)
 	//For simplicity we just always add the newline
 	content += '\n';
-	//We need to slice of the /content part, as well as the /<bundle>/files part
-	let name = bundleState.bundlePathParts.slice(2, -1).join('/');
+	//We need to slice of the /content part at the end, as well as the /files part at the beginning (second part)
+	let nameParts = bundleState.bundlePathParts.slice(0, -1);
+	nameParts.splice(1, 1);
+	let name = nameParts.join('/');
 	res += bundleState.add(content, name, module.sourceMap);
 
 	res += bundleState.add('}');

--- a/src/dependencyResolvers/resolveNodeModule.js
+++ b/src/dependencyResolvers/resolveNodeModule.js
@@ -27,7 +27,14 @@ module.exports = function resolveNodeModule(dep, opts, cb) {
 		opts.resolve(file, onSuccess((res) => {
 			if (res) {
 				dep.file = res.file;
-				dep.base = res.base;
+				//If a path entry is a subpath of the rootpath then we add is as if it were a relative path.
+				//Otherwise we would end up with files having two absolute paths in the bundle, which we
+				//can't represent properly
+				if (res.file.startsWith(opts.base)) {
+					dep.base = opts.base;
+				} else {
+					dep.base = res.base;
+				}
 				dep.as = res.as;
 				debug(`Resolved ${dep.to} from ${dep.from} to ${res.file}`);
 				cb(null, dep);

--- a/src/dependencyResolvers/resolvePath.js
+++ b/src/dependencyResolvers/resolvePath.js
@@ -21,6 +21,7 @@ module.exports = function resolveNodeModule(dep, opts, cb) {
 			//No path, nothing to do
 			return cb(null, dep);
 		}
+		let pathName = pathArray[0].name;
 		let pathEntry = pathArray[0].path;
 		let file = path.join(pathEntry, dep.to);
 		debug(`Trying to load ${dep.to} from ${dep.from} as ${file}`);
@@ -37,6 +38,11 @@ module.exports = function resolveNodeModule(dep, opts, cb) {
 					dep.base = pathEntry;
 				}
 				dep.as = res.as;
+				//If we have given a name for the path than we will use that to generate a dependency name.
+				//that'll be used later for sourcemaps and stuff
+				if (pathName) {
+					dep.name = path.join(pathName, path.relative(pathEntry, dep.file));
+				}
 				debug(`Resolved ${dep.to} from ${dep.from} to ${res}`);
 				cb(null, dep);
 			} else {

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,10 @@ if (process.env.YOLOADER_PROFILE) {
 
 let transformers = {
 
+	compile(instance, compile) {
+		return compile();
+	},
+
 	/**
 	 * Finds and attaches dependencies of a file
 	 */
@@ -132,7 +136,7 @@ let transformers = {
 			timer.stop();
 			newFiles.forEach((file) => {
 				let timer = startTimer('compileDepsTrigger');
-				compile(vinylFs.src(file.file, { base : file.base }))
+				vinylFs.src(file.file, { base : file.base })
 					.pipe(resolver.resolveDependencies())
 					.pipe(through.obj((chunk, enc, cb) => {
 						outer.push(chunk);
@@ -317,6 +321,7 @@ let transformers = {
 
 
 let dependencyPipeline = [
+	transformers.compile,
 	transformers.findDependencies,
 	transformers.resolveDependencies,
 	transformers.compileDependencies,


### PR DESCRIPTION
After the latest release files that where passed to resolveDependencies wouldn't be compiled. As a result sourcemaps wouldn't be applied if these where initialized in the compile function.

As a result there's also a slight change in implementation of the compile function: it should now return a transform stream instead of accepting a stream and returning one. It's basically the same difference, but a whole lot easier on the yoloader side of things.

@Magnetme/developers - plz review