### PR TITLE
Prevent reprocessing dependencies that are already present on chunk

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,11 @@ let transformers = {
 		instance.dependencyCache = instance.dependencyCache || new VinylCache();
 
 		return through.obj((chunk, enc, done) => {
+			//If there are already deps set then the chunk probably comes from some cache. We won't bother
+			//changing it then, it'll only mess up things.
+			if (chunk.deps) {
+				return done(null, chunk);
+			}
 			//We first try to get dependencies from cache.
 			//Only if that fails we'll try to find them again
 			let cachedDeps = instance.dependencyCache.get(chunk);
@@ -83,7 +88,6 @@ let transformers = {
 
 				//Update cache stuff
 				instance.dependencyCache.set(chunk, chunk.deps);
-
 				timer.stop();
 			}
 			done(null, chunk);


### PR DESCRIPTION
This turned out to be problematic with caching: a chunk that is reused from
cache can be in multiple phases of the pipeline at once. It therefore could
happen that it's `dep` property would be reset to the empty object just before
it was about to enter the `linkDependencies` transform, which needs the `dep`
property.

We now assume that if a `dep` object is present that it is created by yoloader
and can therefore safely be reused.

@Magnetme/developers - Ready for review!