### PR TITLE
Reversed variable name and package name for shimconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,12 @@ Allows non-CommonJS modules to be used as CommonJS module. It adds `require` cal
 Example:
 ```javascript
 var shimConfig = {};
-shimConfig[pathToAngularJs] = {
+shimConfig['angular'] = {
 	depends : {
-		//results in `var jQuery = require('jquery');`
-		'jQuery' : 'jquery'
+		//results in `var $ = require('jquery');`
+		'jquery' : '$'
+		//results in `require('somePackage');`
+		'somePackage' : null
 	},
 	//results in `module.exports = angular`
 	exports : 'angular'
@@ -184,7 +186,7 @@ function compile() {
 
 ```
 
-Keys for the shimconfig may also be node package names or glob patterns.
+Keys for the shimconfig object may be node package names, paths or glob patterns.
 
 #### packageCompile
 

--- a/src/plugins/shim.js
+++ b/src/plugins/shim.js
@@ -47,13 +47,8 @@ function findShim(file, shims, packageShims, cb) {
 	if (!shim) {
 		//If we still haven't found a shim here then we try a package based shim
 		let keys = Object.keys(packageShims);
-		//First we skip the obvious base case: if there is no packageShim definition then there's nothing
-		//to do here
-		if (!keys.length) {
-			return cb();
-		}
 		//First we simply try to match on filename
-		let shim = keys
+		let shimKey = keys
 			.find((shimKey) => {
 				let shimFile = shimKey;
 				//require calls don't require .js, so we don't either
@@ -65,6 +60,7 @@ function findShim(file, shims, packageShims, cb) {
 					//not as filename
 					file.endsWith('node_modules/' + shimKey + '/index.js');
 			});
+		shim = shimKey && packageShims[shimKey];
 		if (shim) {
 			return cb(null, shim);
 		}
@@ -127,9 +123,9 @@ module.exports = function shim(shims) {
 							let varName = shim.depends[dependency];
 							let requireStatement = '';
 							if (varName) {
-								requireStatement += `${varname}=`;
+								requireStatement += `${varName}=`;
 							}
-							requireStatement += 'require(${requireString})';
+							requireStatement += `require(${requireString})`;
 							return requireStatement;
 						});
 					prefix = 'var ' + requires.join(',') + ';';

--- a/src/plugins/shim.js
+++ b/src/plugins/shim.js
@@ -119,12 +119,18 @@ module.exports = function shim(shims) {
 				let suffix = '';
 				//Add require calls when needed
 				if (shim.depends) {
-					//Depends is a map of <var-name>:<require-name> pairs
+					//Depends is a map of <require-name>:<var-name> pairs
 					let requires = Object.keys(shim.depends)
 						.map((dependency) => {
 							//stringify to ensure valid js
-							let requireString = JSON.stringify(shim.depends[dependency]);
-							return `${dependency}=require(${requireString})`;
+							let requireString = JSON.stringify(dependency);
+							let varName = shim.depends[dependency];
+							let requireStatement = '';
+							if (varName) {
+								requireStatement += `${varname}=`;
+							}
+							requireStatement += 'require(${requireString})';
+							return requireStatement;
 						});
 					prefix = 'var ' + requires.join(',') + ';';
 				}


### PR DESCRIPTION
Not all packages export anything. Some packages just put something on the
window object, and others don't even expose anything at all but register
listeners/services etc. in other frameworks. If the variable name is the key
of the depends config then it's not possible to instruct yoloader to just
require the module, but not assign it to a variable. Therefore this has now
been changed such that the variable name is the value and the package name is
the key. This allows the user to set the variable name to , which causes
yoloader to not use the exported value

@Magnetme/developers