### PR TITLE
Fixes for packageCompile and shim plugins

### DIFF
--- a/src/plugins/packageCompile.js
+++ b/src/plugins/packageCompile.js
@@ -127,7 +127,7 @@ module.exports = function packageCompile(opts, globalOptions) {
 		let outerStream = this;
 		//We need to find the package.json of our chunk to find the compiler configuration
 		//The package.json#yoloaderCompile field should contain the filename of the module compiler
-		mothership(chunk.path, () => true, (err, res) => {
+		mothership(chunk.path, (pack) => !!pack.yoloaderCompile, (err, res) => {
 			if (err) {
 				return done(new Error(err));
 			}

--- a/src/plugins/shim.js
+++ b/src/plugins/shim.js
@@ -79,9 +79,11 @@ function findShim(file, shims, packageShims, cb) {
 					isMain = mainFile.reduce((previous, current) => {
 						return current && path.join(path.dirname(res.path), current) === file;
 					}, false);
-				} else if (!mainFile || typeof mainFile !== 'string') {
-					//Default value
-					mainFile = 'index.js';
+				} else {
+					if (!mainFile || typeof mainFile !== 'string') {
+						//Default value
+						mainFile = 'index.js';
+					}
 					isMain = path.join(path.dirname(res.path), mainFile) === file;
 				}
 				let shim = isMain && packageShims[res.pack.name];

--- a/src/plugins/shim.js
+++ b/src/plugins/shim.js
@@ -96,7 +96,11 @@ function findShim(file, shims, packageShims, cb) {
 /**
  * Provides a shim for non-commonjs files.
  */
-module.exports = function shim(shims) {
+module.exports = function shim(shimsIn) {
+	let shims = {};
+	//We need to clone the shims first because we destruct the object in the process
+	Object.keys(shimsIn)
+		.forEach((key) => shims[key] = shimsIn[key]);
 	let packageShims = extractPackageShims(shims);
 
 	return through.obj((chunk, enc, done) => {


### PR DESCRIPTION
In this PR:
- PackageCompile now recursively searches for package.json with a yoloaderCompile field (it previously stopped at the first package.json, regardless of a yoloaderCompile field). The idea behind this is that the yoloFile should be able to shim other dependencies, but therefore the packageCompile plugin needs to traverse further than the first package.json for non-yoloader compatible packages.
- There was a bug in the shim plugin for parsing the main field, which caused some files to miss its shim config
- The shim plugin destroyed its argument. This isn't very handy, so now it first clones the argument before working with it.

@Magnetme/developers - Ready for review, but merging already cause #yolo (need it).